### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.anshulg]
+index = "sparse+https://crates.anshulg.com:443/api/v1/crates/"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.
-    tags: [ '*.*.*' ]
+    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,54 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRIES_ANSHULG_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRIES_ANSHULG_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: CD
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'ansg191'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: aarch64-apple-darwin
+            os: macos-13
+          - target: aarch64-pc-windows-msvc
+            os: windows-2022
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+          - target: x86_64-unknown-freebsd
+            os: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
+      - uses: taiki-e/install-action@cross
+        if: contains(matrix.target, '-musl')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: kanidm-auth-plugin
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+semver_check = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ansg191/arr-backup/releases/tag/v0.1.0) - 2024-12-01
+
+### Other
+
+- Add releasing CI and config
+- Add LICENSE
+- Merge pull request [#22](https://github.com/ansg191/arr-backup/pull/22) from ansg191/renovate/tokio-tracing-monorepo
+- Fix compilation errors
+- Update Rust crate ureq to v3.0.0-rc3
+- Add Github Actions rust CI
+- Add rust build to builds.sr.ht
+- Update alpine Docker tag to v3.20
+- Add sr.ht publishing to docker hub
+- Add sr.ht `.build.yml`
+- Replace with cargo-zigbuild
+- Remove app_name docker arg
+- Switch back to qemu docker build
+- Replace json logs with nested logs
+- Update Rust crate zip to v2.2.1
+- Update docker/metadata-action digest to 369eb59
+- Update renovatebot/github-action action to v41.0.3
+- Update rust:1.82-alpine Docker digest to 2f42ce0
+- Merge pull request [#9](https://github.com/ansg191/arr-backup/pull/9) from ansg191/renovate/rust-1.82-alpine
+- Update Rust crate serde to v1.0.215
+- Switch to tracing
+- Pin dependencies
+- Pin xx to 1.5.0
+- Update docker/build-push-action action to v6
+- Update renovate.json
+- Add renovate.json
+- Add renovate
+- Speed up docker build
+- Run docker build on PR
+- Add `json` logging with env variable switch
+- Rewrite archive expansion to ignore perms
+- Add context to `copy_backup` errors
+- Remove Cargo.lock from .gitignore
+- Remove annoying gitignore thing
+- Initial Commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "arr-backup"
+description = "Executable to download backups from *arr apps"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+publish = ["anshulg"]
 
 [dependencies]
 anyhow = "1.0.92"


### PR DESCRIPTION
## 🤖 New release
* `arr-backup`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/ansg191/arr-backup/releases/tag/v0.1.0) - 2024-12-01

### Other

- Add releasing CI and config
- Add LICENSE
- Merge pull request [#22](https://github.com/ansg191/arr-backup/pull/22) from ansg191/renovate/tokio-tracing-monorepo
- Fix compilation errors
- Update Rust crate ureq to v3.0.0-rc3
- Add Github Actions rust CI
- Add rust build to builds.sr.ht
- Update alpine Docker tag to v3.20
- Add sr.ht publishing to docker hub
- Add sr.ht `.build.yml`
- Replace with cargo-zigbuild
- Remove app_name docker arg
- Switch back to qemu docker build
- Replace json logs with nested logs
- Update Rust crate zip to v2.2.1
- Update docker/metadata-action digest to 369eb59
- Update renovatebot/github-action action to v41.0.3
- Update rust:1.82-alpine Docker digest to 2f42ce0
- Merge pull request [#9](https://github.com/ansg191/arr-backup/pull/9) from ansg191/renovate/rust-1.82-alpine
- Update Rust crate serde to v1.0.215
- Switch to tracing
- Pin dependencies
- Pin xx to 1.5.0
- Update docker/build-push-action action to v6
- Update renovate.json
- Add renovate.json
- Add renovate
- Speed up docker build
- Run docker build on PR
- Add `json` logging with env variable switch
- Rewrite archive expansion to ignore perms
- Add context to `copy_backup` errors
- Remove Cargo.lock from .gitignore
- Remove annoying gitignore thing
- Initial Commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).